### PR TITLE
Disable fail-fast with github CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,6 +12,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby-version: [ '2.5', '2.6', '2.7', '3.0', '3.1', 'ruby-head' ]
 


### PR DESCRIPTION
Doesn't cancel all jobs when one failed