### PR TITLE
Deprecate ruby 2.5 support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [ '2.5', '2.6', '2.7', '3.0', '3.1', 'ruby-head' ]
+        ruby-version: [ '2.6', '2.7', '3.0', '3.1', 'ruby-head' ]
     steps:
     - uses: actions/checkout@v3
     - name: Setup ruby

--- a/pvoutput.gemspec
+++ b/pvoutput.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency 'httparty'
 


### PR DESCRIPTION
    * .github/workflows/ruby.yml:
    * pvoutput.gemspec: